### PR TITLE
Optimize ci pipeline tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -80,7 +80,7 @@ jobs:
 
   # Short test on ubuntu using PS7 without batching
   integration_test_short_ubuntu_ps7_no_batching:
-    name: Long, Ubuntu, PS7, batching disabled
+    name: Short, Ubuntu, PS7, batching disabled
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -61,7 +61,7 @@ jobs:
 
 
   # Long test on ubuntu using PS7
-  integration_test_long_ubuntu_ps7_batching:
+  integration_test_long_ubuntu_ps7:
     name: Long, Ubuntu, PS7, batching enabled
     runs-on: ubuntu-20.04
     steps:
@@ -78,8 +78,8 @@ jobs:
           ./business_objects_upload/test/TestWrapperScript.ps1 -dbType csv -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/csv/ScriptConfig.template.json
 
 
-  # Long test on ubuntu using PS7
-  integration_test_long_ubuntu_ps7:
+  # Short test on ubuntu using PS7 without batching
+  integration_test_short_ubuntu_ps7_no_batching:
     name: Long, Ubuntu, PS7, batching disabled
     runs-on: ubuntu-20.04
     steps:
@@ -93,12 +93,12 @@ jobs:
         shell: pwsh
         run: |
           echo "Test CSV import"
-          ./business_objects_upload/test/TestWrapperScript.ps1 -noBatching -dbType csv -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/csv/ScriptConfig.template.json
+          ./business_objects_upload/test/TestWrapperScript.ps1 -short -noBatching -dbType csv -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/csv/ScriptConfig.template.json
 
 
   release:
     name: Release
-    needs: [integration_test_long_ubuntu_ps7, integration_test_short_windows_ps5, integration_test_short_windows_ps7, integration_test_short_ubuntu_ps7_mssql, integration_test_long_ubuntu_ps7_batching]
+    needs: [integration_test_long_ubuntu_ps7, integration_test_short_windows_ps5, integration_test_short_windows_ps7, integration_test_short_ubuntu_ps7_mssql, integration_test_short_ubuntu_ps7_no_batching]
     runs-on: ubuntu-20.04
     # Only run this job when a tag is pushed that starts with a 'v'
     # Goal is to refactor this job into another workflow. But that is not supported in the moment.
@@ -136,7 +136,7 @@ jobs:
         integration_test_short_windows_ps5,
         integration_test_short_windows_ps7,
         integration_test_short_ubuntu_ps7_mssql,
-        integration_test_long_ubuntu_ps7_batching,
+        integration_test_short_ubuntu_ps7_no_batching,
         release
       ]
     steps:

--- a/.github/workflows/integration-tests_triggered_by_bo.yaml
+++ b/.github/workflows/integration-tests_triggered_by_bo.yaml
@@ -127,7 +127,7 @@ jobs:
 
   # Short test on ubuntu using PS7
   integration_test_short_ubuntu_ps7_no_batching:
-    name: Long, Ubuntu, PS7, version, batching disabled '${{ matrix.version }}'
+    name: Short, Ubuntu, PS7, version, batching disabled '${{ matrix.version }}'
     needs: [setup]
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/integration-tests_triggered_by_bo.yaml
+++ b/.github/workflows/integration-tests_triggered_by_bo.yaml
@@ -6,8 +6,8 @@ on:
   schedule:
     # Executes this workflow on a schedule (always uses the latest version on the default branch
     # (see: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule))
-    # Execution every day at 02:00
-    - cron: "0 2 * * *"
+    # Execution on weekdays at 02:27 UTC
+    - cron: "27 2 * * 1-5"
   workflow_dispatch:
     inputs:
       bo_env:
@@ -102,7 +102,7 @@ jobs:
           ./business_objects_upload/test/TestWrapperScript.ps1 -dbPassword ${{ secrets.MSSQL_DB_PASSWORD_TEST }} -dbType mssql -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/mssql/ScriptConfig.template.json
 
   # Long test on ubuntu using PS7
-  integration_test_long_ubuntu_ps7_batching:
+  integration_test_long_ubuntu_ps7:
     name: Long, Ubuntu, PS7, version, batching enabled '${{ matrix.version }}'
     needs: [setup]
     runs-on: ubuntu-20.04
@@ -125,8 +125,8 @@ jobs:
           echo "Test CSV import"
           ./business_objects_upload/test/TestWrapperScript.ps1 -dbType csv -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/csv/ScriptConfig.template.json
 
-  # Long test on ubuntu using PS7
-  integration_test_long_ubuntu_ps7:
+  # Short test on ubuntu using PS7
+  integration_test_short_ubuntu_ps7_no_batching:
     name: Long, Ubuntu, PS7, version, batching disabled '${{ matrix.version }}'
     needs: [setup]
     runs-on: ubuntu-20.04
@@ -147,7 +147,7 @@ jobs:
         shell: pwsh
         run: |
           echo "Test CSV import"
-          ./business_objects_upload/test/TestWrapperScript.ps1 -noBatching -dbType csv -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/csv/ScriptConfig.template.json
+          ./business_objects_upload/test/TestWrapperScript.ps1 -short -noBatching -dbType csv -baseUri ${{ secrets.BO_BASE_URI_TEST }} -apiKey "${{ secrets.BO_API_KEY_TEST }}" -configTemplatePath ./business_objects_upload/test/csv/ScriptConfig.template.json
 
   notify-teams:
     runs-on: ubuntu-latest
@@ -158,7 +158,7 @@ jobs:
         integration_test_short_windows_ps5,
         integration_test_short_windows_ps7,
         integration_test_short_ubuntu_ps7_mssql,
-        integration_test_long_ubuntu_ps7_batching
+        integration_test_short_ubuntu_ps7_no_batching
       ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Perfomed various improvements in the ci pipeline:

- The test `integration_test_long_ubuntu_ps7` that tests the script with batching disabled was refactored from a long (import of 1.000 entities) to a short test (import of just 10 entities)
- Pipeline is now only scheduled on weekdays insted of every day as before